### PR TITLE
Script to generate author list from Google Docs

### DIFF
--- a/CWP/papers/roadmap/authors/a2tex.py
+++ b/CWP/papers/roadmap/authors/a2tex.py
@@ -1,0 +1,68 @@
+#! /usr/bin/env python
+#
+# Process CWP signatory list into a LaTeX author list
+
+import os
+import re
+import sys
+
+def main():
+    author_file = "authors.txt"
+    footnote_file = "footnotes.txt"
+
+    # Open and process the authors file
+    with open(author_file) as author_fh, open(footnote_file) as footnote_fh:
+        author_list = []
+        for author_line in author_fh:
+            if author_line.startswith("#"):
+                continue
+            author_elements = [ el.strip() for el in author_line.split(" - ") ]
+            try:
+                surname, forename = [ el.strip() for el in author_elements[0].split(",", 1) ]
+                affiliation = author_elements[1]
+                if len(author_elements) == 3:
+                    role = author_elements[2]
+                else:
+                    role = ""
+                author_list.append( {"surname": surname,
+                     "forename": forename,
+                     "affiliation": affiliation.replace("&", "\&"),
+                     "role": role.replace("&", "\&"),}
+                    )
+            except:
+                print "Got an exception processing this line:", author_line
+        
+        print author_list
+
+    # Generate the map to people's institutes
+    affiliation_map = {}
+    for author in author_list:
+        if author["affiliation"] in affiliation_map:
+            continue
+        affiliation_map[author["affiliation"]] = {
+            "address": author["affiliation"],
+            }
+    # Alphabetise and assign footnote marks
+    sorted_affiliations = affiliation_map.keys()[:]
+    sorted_affiliations.sort()
+    for footnote_mark, affiliation in enumerate(sorted_affiliations, start=1):
+        affiliation_map[affiliation]["footnotemark"] = str(footnote_mark)
+    
+        
+    # Write out the latex author file
+    with open("authors.tex", "w") as output:
+        for author in author_list:
+            print >>output, author["surname"] +", "  + \
+            author["forename"] + "$^{" + str(affiliation_map[author["affiliation"]]["footnotemark"]) + "}$" +\
+            ("" if author == author_list[-1] else ";")
+            #if author["role"]:
+            #    print >>output, "(" + author["role"] + ")"
+        print >>output
+        for affiliation in sorted_affiliations:
+            print affiliation
+            print >>output, "\par {\\footnotesize $^{" + str(affiliation_map[affiliation]["footnotemark"]) + "}$", affiliation_map[affiliation]["address"], "}"
+
+
+if __name__ == '__main__':
+    main()
+

--- a/CWP/papers/roadmap/authors/a2tex.py
+++ b/CWP/papers/roadmap/authors/a2tex.py
@@ -1,10 +1,15 @@
 #! /usr/bin/env python
 #
 # Process CWP signatory list into a LaTeX author list
-
-# The data source is expected to be 
-#   Lastname, Firstname - Institution (1) [- Role ]
-# If there are multiple affiliations, separate with &
+#
+# The data source is expected to be made of 3 text files:
+#    - authors.txt: the list of signers in the following format: Lastname, Firstname - AffiliationKey (i) [- Role ]
+#      with i a footnote number. If there are multiple affiliations, separate AffiliationKeys with &.
+#    - footnotes:txt: the list of footnotes. There must be one footnote per line starting with 'i.'
+#    - address.txt: the affiliation list with the following format: AffilitationKey: Affiliation text
+#      AffiliationKey must not contain any space.
+#
+# These 3 files are typically built from the Google Docs https://docs.google.com/document/d/1tBXwlNnQsxxZA3gVS1_KSpa8wRXGyk250EIsJwJ2T34/edit#
 
 import os
 import re

--- a/CWP/papers/roadmap/authors/a2tex.py
+++ b/CWP/papers/roadmap/authors/a2tex.py
@@ -3,17 +3,29 @@
 # Process CWP signatory list into a LaTeX author list
 #
 # The data source is expected to be made of 3 text files:
-#    - authors.txt: the list of signers in the following format: Lastname, Firstname - AffiliationKey (i) [- Role ]
+#    - authors.txt: the list of signers in the following format: Lastname, Firstname - AffiliationKey [- Role ] (i)
 #      with i a footnote number. If there are multiple affiliations, separate AffiliationKeys with &.
 #    - footnotes:txt: the list of footnotes. There must be one footnote per line starting with 'i.'
 #    - address.txt: the affiliation list with the following format: AffilitationKey: Affiliation text
 #      AffiliationKey must not contain any space.
 #
-# These 3 files are typically built from the Google Docs https://docs.google.com/document/d/1tBXwlNnQsxxZA3gVS1_KSpa8wRXGyk250EIsJwJ2T34/edit#
+# These 3 files are typically built from the Google Docs https://docs.google.com/document/d/1tBXwlNnQsxxZA3gVS1_KSpa8wRXGyk250EIsJwJ2T34
+#
+# Note: this script requires Python >= 3.5
+#
+# Initial version written by Graeme Stewart (graeme.andrew.stewart@cern.ch) and Michel Jouvin (jouvin@lal.in2p3.fr)
+
+import sys
+PYTHON_MIN = (3, 5)
+major, minor, _, _, _ = sys.version_info
+if (major, minor) < PYTHON_MIN:
+    python_min_str = '.'.join(str(x) for x in PYTHON_MIN)
+    # Keep old formatter syntax to be sure it works with old version of Python
+    print ("This script requires Python %s or later" % python_min_str)
+    sys.exit(2)
 
 import os
 import re
-import sys
 from operator import attrgetter
 import argparse
 

--- a/CWP/papers/roadmap/authors/a2tex.py
+++ b/CWP/papers/roadmap/authors/a2tex.py
@@ -65,6 +65,27 @@ class Affiliation():
     def set_mark(self, i):
         self.mark = str(i)
 
+def latex_escape(string):
+    """
+    Function to escape latex reserved characters
+    :param string: the string containing the characters to escape
+    :return: the escaped string
+    """
+
+    CHARS_TO_ESCAPE_PATTERN = re.compile(r'(?<!\\)(?P<char>[&%\$#_{}])')
+    SPECIAL_LATEX_CHARS = {'~':'$\\\\textasciitilde$',
+                           '^':'$\\\\textasciicircum$'}
+    # Do not attempt to escape \ as it may have been added as an escape character
+    # and is unlikely to be present in an affiliation or footnote...
+    # If it is present, if will have to be escaped manually
+    #                       '\\':'$\\\\textbackslash$'}
+    # Escape all reserved characters that can be escaped
+    string = CHARS_TO_ESCAPE_PATTERN.sub('\\\\\g<char>', string)
+    # Then replace special chars
+    for special_char, repl in SPECIAL_LATEX_CHARS.items():
+       string = re.sub(re.escape(special_char), repl, string)
+    return string
+
 def main():
 
     try:
@@ -149,13 +170,13 @@ def main():
         print ("\\bigskip", file=output)
         for affiliation in sorted_affiliations:
             print ("\\par {{\\footnotesize $^{{{}}}$ {}}}".format(str(affiliation_map[affiliation].mark),
-                                                               affiliation_map[affiliation].address),
+                                                                  latex_escape(affiliation_map[affiliation].address)),
                    file=output)
 
         print ("\\bigskip", file=output)
         for footnote in sorted_footnotes:
             print ("\\par {{\\footnotesize $^{{{}}}$ {}}}".format(footnote.mark,
-                                                                 footnote.text),
+                                                                  latex_escape(footnote.text)),
                    file=output)
 
 

--- a/CWP/papers/roadmap/authors/a2tex.py
+++ b/CWP/papers/roadmap/authors/a2tex.py
@@ -131,7 +131,7 @@ def main():
         
     # Write out the latex author file
     with open(options.output_file, "w", encoding="utf-8") as output:
-        for author in author_list:
+        for author in sorted(author_list, key=lambda author: author.surname):
             affiliation_list = ",".join([ affiliation_map[affiliation].mark for affiliation in author.affiliations ])
             if author.footnotes:
                 footnote_str = ",".join( [ footnote_list[int(id)-1].mark for id in author.footnotes ])

--- a/CWP/papers/roadmap/authors/address.txt
+++ b/CWP/papers/roadmap/authors/address.txt
@@ -1,3 +1,6 @@
 # Simple mapping of institute names to addresses
 CERN: CERN, Geneva, Switzerland
-
+Fermilab: Fermi National Accelerator Laboratory, Batavia, USA
+ANL: High Energy Physics Division, Argonne National Laboratory, Argonne IL, USA
+BNL: Physics Department, Brookhaven National Laboratory, Upton NY, USA
+LBNL: Lawrence Berkeley National Laboratory and University of California, Berkeley CA, USA

--- a/CWP/papers/roadmap/authors/address.txt
+++ b/CWP/papers/roadmap/authors/address.txt
@@ -1,0 +1,3 @@
+# Simple mapping of institute names to addresses
+CERN: CERN, Geneva, Switzerland
+

--- a/CWP/papers/roadmap/authors/address.txt
+++ b/CWP/papers/roadmap/authors/address.txt
@@ -1,6 +1,113 @@
-# Simple mapping of institute names to addresses
-CERN: CERN, Geneva, Switzerland
-Fermilab: Fermi National Accelerator Laboratory, Batavia, USA
 ANL: High Energy Physics Division, Argonne National Laboratory, Argonne IL, USA
 BNL: Physics Department, Brookhaven National Laboratory, Upton NY, USA
+Caltech: California Institute of Technology, Pasadena, California, USA
+CBPF: Centro Brasileiro de Pesquisas Fisicas, Rio de Janeiro, Brazil
+CCIN2P3: Centre de Calcul de l’IN2P3, Villeurbanne, Lyon, France
+CERN: CERN, Geneva, Switzerland
+CIEMAT: Centro de Investigaciones Energéticas Medioambientales y Tecnológicas (CIEMAT), Madrid, Spain
+CHICAGO: Enrico Fermi Institute, University of Chicago, Chicago IL, USA
+CINVESTAV: Cinvestav, Mexico City, Mexico
+CNAF: Centro Nazionale Analisi Fotogrammi (CNAF), INFN, Bologna, Italy
+Cornell: Cornell University, Ithaca, USA
+CPHC: Center for High Performance Computing, Cape Town, South Africa
+DESY: Deutsches Elektronen-Synchrotron, Hamburg, Germany
+EPFL: Institute of Physics, Ecole Polytechnique Federale de Lausanne (EPFL), Lausanne, Switzerland
+ETHZurich: ETH Zurich - Institute for Particle Physics and Astrophysics (IPA), Zurich, Switzerland
+Fermilab: Fermi National Accelerator Laboratory, Batavia, USA
+HAMBURG: University of Hamburg, Hamburg, Germany
+HIP: Helsinki Institute of Physics, Helsinki, Finland
+IFAE: Institut de Física d’Altes Energies and Departament de Física de la Universitat Autònoma de Barcelona and ICREA, Barcelona, Spain
+IFCA: Instituto de Física de Cantabria (IFCA), CSIC-Universidad de Cantabria, Santander, Spain
+IFICValencia: Instituto de Fisica Corpuscular, Centro Mixto Universidad de Valencia - CSIC, Valencia, Spain
+IHEPCHINA: Institute of High Energy Physics, Chinese Academy of Sciences, Beijing
+INDIANA: Department of Physics, Indiana University, Bloomington IN, USA
+INFNBOLOGNA: INFN Sezione di Bologna, Università di Bologna, Bologna, Italy
+INFNFerrara: Universita e INFN, Ferrara, Ferrara, Italy
+INFNBari: INFN Sezione di Bari, Università di Bari, Politecnico di Bari, Bari, Italy
+INFNMilano: INFN Sezione di Milano-Bicocca, Milano, Italy
+INFNNapoli: INFN Sezione di Napoli, Università di Napoli, Napoli, Italy
+INFNPadova: INFN Sezione di Padova, Università di Padova b, Padova, Italy
+INFNPISA: INFN Sezione di Pisa, Università di Pisa, Scuola Normale Superiore di Pisa, Pisa, Italy
+INFNRoma: INFN Sezione di Roma I, Università La Sapienza, Roma, Italy
+INFNTRIESTE: INFN Sezione di Trieste, Università di Trieste, Trieste, Italy
+IPHC: Université de Strasbourg, CNRS, IPHC UMR 7178, F-67000 Strasbourg, France
+Irfu: DSM/IRFU (Institut de Recherches sur les Lois Fondamentales de l’Univers), CEA Saclay (Commissariat a l’Energie Atomique), Gif-sur-Yvette, France
+JLab: Thomas Jefferson National Accelerator Facility, Newport News, Virginia, USA
+JSI: Jozef Stefan Institute, Ljubljana, Slovenia
+KIT: Karlsruhe Institute of Technology, Karlsruhe, Germany
+KRAKOWUST: AGH University of Science and Technology, Faculty of Physics and Applied Computer Science, Krakow, Poland
+KYUNGPOOK: Kyungpook National University, Daegu, Republic of Korea
+Imperial: Imperial College London, London, United Kingdom
+LAL: LAL, Université Paris-Sud and CNRS/IN2P3, Orsay, France
 LBNL: Lawrence Berkeley National Laboratory and University of California, Berkeley CA, USA
+LIP: Laboratorio de Instrumentacao e Fisica Experimental de Particulas (LIP), Lisboa, Portugal
+LLR: Laboratoire Leprince-Ringuet, Ecole polytechnique, CNRS/IN2P3, Université Paris-Saclay, Palaiseau, France
+LMU: Fakultät für Physik, Ludwig-Maximilians-Universität München, München, Germany
+LPCClermont: Laboratoire de Physique Corpusculaire, Clermont Université and Université Blaise Pascal and CNRS/IN2P3, Clermont-Ferrand, France
+LPNHE: LPNHE, Universite Pierre et Marie Curie, Universite Paris Diderot, CNRS/IN2P3, Paris, France
+LPSC: Laboratoire de Physique Subatomique et de Cosmologie, Université Joseph Fourier and CNRS/IN2P3 and Institut National Polytechnique de Grenoble, Grenoble, France
+MIT: Department of Physics, University of Massachusetts, Amherst, MA, USA
+MPP: Max-Planck-Institut für Physik (Werner-Heisenberg-Institut), München, Germany
+NBI: Niels Bohr Institute, University of Copenhagen, Kobenhavn, Denmark
+NIKHEF: Nikhef National Institute for Subatomic Physics and University of Amsterdam, Amsterdam, Netherlands
+NYU: Department of Physics, New York University, New York, NY, USA
+OREGON: Center for High Energy Physics, University of Oregon, Eugene OR, USA
+PIC: Port d’Informació Científica (PIC), Universitat Autònoma de Barcelona (UAB), Barcelona, Spain
+RAL: STFC Rutherford Appleton Laboratory, Didcot, United Kingdom
+RHU: Department of Physics, Royal Holloway University of London, Surrey, United Kingdom
+SimonsFoundation: Simons Foundation, New York, USA
+SLAC: SLAC National Accelerator Laboratory, Menlo Park CA, USA
+Subatech: SUBATECH, IMT Atlantique, Université de Nantes, CNRS-IN2P3, Nantes, France
+TAIWAN: National Taiwan University, Taipei, Taiwan
+TIFR: Tata Institute of Fundamental Research, Mumbai, India
+UAlberta: Department of Physics, University of Alberta, Edmonton, AB, Canada
+UAmherst: Department of Physics, University of Massachusetts, Amherst, MA, USA
+UArizona: Department of Physics, University of Arizona, Tucson, AZ, USA
+UBristol: H.H. Wills Physics Laboratory, University of Bristol, Bristol, United Kingdom
+UBritishColumbia: Department of Physics, University of British Columbia, Vancouver, BC, Canada
+UCambridge: Cavendish Laboratory, University of Cambridge, Cambridge, United Kingdom
+UCape: Physics Department, University of Cape Town, Cape Town, South Africa
+UChampaign: University of Illinois Urbana-Champaign, Champaign, Illinois, USA
+UChicago: Enrico Fermi Institute, University of Chicago, Chicago, IL, USA
+UCincinnati: University of Cincinnati, Cincinnati, OH, USA
+UCIrvine: Department of Physics and Astronomy, University of California Irvine, Irvine, CA, USA
+UCSD: University of California, San Diego, La Jolla, USA
+UDuke: Department of Physics, Duke University, Durham, NC, USA
+UGangneung: Gangneung-Wonju National University, South Korea
+UGlasgow: SUPA - School of Physics and Astronomy, University of Glasgow, Glasgow, United Kingdom
+UEDINBURGH: SUPA - School of Physics and Astronomy, University of Edinburgh, Edinburgh, United Kingdom
+UGeneva: Section de Physique, Université de Genève, Geneva, Switzerland
+UHeidelberg: Physikalisches Institut, Ruprecht-Karls-Universitat Heidelberg, Heidelberg, Germany
+UKentucky: Department of Physics \& Astronomy, University of Kentucky, Lexington, USA
+ULancaster: Physics Department, Lancaster University, Lancaster, United Kingdom
+ULjubljana: Department of Physics, Jožef Stefan Institute and University of Ljubljana, Ljubljana, Slovenia
+ULund: Fysiska institutionen, Lunds universitet, Lund, Sweden
+UManchester: School of Physics and Astronomy, University of Manchester, Manchester, United Kingdom
+UMaribor: University of Maribor, Ljubljana, Slovenia
+UMich: Department of Physics, The University of Michigan, Ann Arbor, MI, USA
+UMinho: Departamento de Fisica, Universidade de Minho, Braga, Portugal
+UOhio: The Ohio State University, Columbus, USA
+UOKLAHOMA: Homer L. Dodge Department of Physics and Astronomy, University of Oklahoma, Norman OK, USA
+UOslo: Department of Physics, University of Oslo, Oslo, Norway
+UNebraska: University of Nebraska-Lincoln, Lincoln, USA
+UNotreDame: University of Notre Dame, Notre Dame, USA
+UNewMexico: Department of Physics and Astronomy, University of New Mexico, Albuquerque NM, USA
+UOSLO: Department of Physics, University of Oslo, Oslo, Norway
+UOviedo: Universidad de Oviedo, Oviedo, Spain
+UPittsburgh: Department of Physics and Astronomy, University of Pittsburgh, Pittsburgh, PA, USA
+UPrinceton: Princeton University, Princeton, USA
+URice: Rice University, Houston, USA
+USaoPaolo: Universidade Estadual Paulista, São Paulo, Brazil
+USapienza: Dipartimento di Fisica, Università La Sapienza, Roma, Italy
+UShandong: School of Physics, Shandong University, Shandong, China
+USheffield: Department of Physics and Astronomy, University of Sheffield, Sheffield, United Kingdom
+USofia: University of Sofia, Sofia, Bulgaria
+UTexas: Department of Physics, The University of Texas at Arlington, Arlington, TX, USA
+UTomsk: National Research Tomsk Polytechnic University, Tomsk, Russia
+UTorronto: Department of Physics, University of Toronto, Toronto, ON, Canada
+UWarwick: Department of Physics, University of Warwick, Coventry, United Kingdom
+UWisconsin: University ofWisconsin - Madison, Madison, WI, USA
+UYale: Department of Physics, Yale University, New Haven, CT, USA
+VAST: IOP and GUST, Vietnam Academy of Science and Technology (VAST), Hanoi, Vietnam
+VIRTECH: Virginia Tech, Blacksburg, Virginia, USA
+WISCONSIN: Department of Physics, University of Wisconsin, Madison WI, USA

--- a/CWP/papers/roadmap/authors/address.txt
+++ b/CWP/papers/roadmap/authors/address.txt
@@ -78,7 +78,7 @@ UGlasgow: SUPA - School of Physics and Astronomy, University of Glasgow, Glasgow
 UEDINBURGH: SUPA - School of Physics and Astronomy, University of Edinburgh, Edinburgh, United Kingdom
 UGeneva: Section de Physique, Université de Genève, Geneva, Switzerland
 UHeidelberg: Physikalisches Institut, Ruprecht-Karls-Universitat Heidelberg, Heidelberg, Germany
-UKentucky: Department of Physics \& Astronomy, University of Kentucky, Lexington, USA
+UKentucky: Department of Physics & Astronomy, University of Kentucky, Lexington, USA
 ULancaster: Physics Department, Lancaster University, Lancaster, United Kingdom
 ULjubljana: Department of Physics, Jožef Stefan Institute and University of Ljubljana, Ljubljana, Slovenia
 ULund: Fysiska institutionen, Lunds universitet, Lund, Sweden
@@ -96,7 +96,7 @@ UOSLO: Department of Physics, University of Oslo, Oslo, Norway
 UOviedo: Universidad de Oviedo, Oviedo, Spain
 UPittsburgh: Department of Physics and Astronomy, University of Pittsburgh, Pittsburgh, PA, USA
 UPrinceton: Princeton University, Princeton, USA
-URice: Rice University, Houston, USA
+URice: Rice University, Houston, TX, USA
 USaoPaolo: Universidade Estadual Paulista, São Paulo, Brazil
 USapienza: Dipartimento di Fisica, Università La Sapienza, Roma, Italy
 UShandong: School of Physics, Shandong University, Shandong, China
@@ -106,8 +106,7 @@ UTexas: Department of Physics, The University of Texas at Arlington, Arlington, 
 UTomsk: National Research Tomsk Polytechnic University, Tomsk, Russia
 UTorronto: Department of Physics, University of Toronto, Toronto, ON, Canada
 UWarwick: Department of Physics, University of Warwick, Coventry, United Kingdom
-UWisconsin: University ofWisconsin - Madison, Madison, WI, USA
+UWisconsin: University of Wisconsin - Madison, Madison, WI, USA
 UYale: Department of Physics, Yale University, New Haven, CT, USA
 VAST: IOP and GUST, Vietnam Academy of Science and Technology (VAST), Hanoi, Vietnam
 VIRTECH: Virginia Tech, Blacksburg, Virginia, USA
-WISCONSIN: Department of Physics, University of Wisconsin, Madison WI, USA

--- a/CWP/papers/roadmap/authors/address.txt
+++ b/CWP/papers/roadmap/authors/address.txt
@@ -19,7 +19,7 @@ HIP: Helsinki Institute of Physics, Helsinki, Finland
 IFAE: Institut de Física d’Altes Energies and Departament de Física de la Universitat Autònoma de Barcelona and ICREA, Barcelona, Spain
 IFCA: Instituto de Física de Cantabria (IFCA), CSIC-Universidad de Cantabria, Santander, Spain
 IFICValencia: Instituto de Fisica Corpuscular, Centro Mixto Universidad de Valencia - CSIC, Valencia, Spain
-IHEPCHINA: Institute of High Energy Physics, Chinese Academy of Sciences, Beijing
+IHEP: Institute of High Energy Physics, Chinese Academy of Sciences, Beijing
 INDIANA: Department of Physics, Indiana University, Bloomington IN, USA
 INFNBOLOGNA: INFN Sezione di Bologna, Università di Bologna, Bologna, Italy
 INFNFerrara: Universita e INFN, Ferrara, Ferrara, Italy

--- a/CWP/papers/roadmap/authors/author_stub.tex
+++ b/CWP/papers/roadmap/authors/author_stub.tex
@@ -1,0 +1,10 @@
+% Stub to test the latex processing of the author list
+
+\documentclass[12pt,a4paper]{article}
+
+\begin{document}
+
+\raggedright
+\input{authors.tex}
+
+\end{document}

--- a/CWP/papers/roadmap/authors/author_stub.tex
+++ b/CWP/papers/roadmap/authors/author_stub.tex
@@ -1,6 +1,7 @@
 % Stub to test the latex processing of the author list
 
 \documentclass[12pt,a4paper]{article}
+\usepackage[utf8]{inputenc}
 
 \begin{document}
 

--- a/CWP/papers/roadmap/authors/authors.txt
+++ b/CWP/papers/roadmap/authors/authors.txt
@@ -28,7 +28,7 @@ Buncic, Predrag - CERN - ALICE Computing Coordinator
 Calafiura, Paolo - LBNL
 Campana, Simone - CERN 
 Canali, Luca - CERN
-Carlino Gianpaolo - INFN
+Carlino, Gianpaolo - INFN
 Castro, Nuno - LIP and University of Minho (4)
 Cattaneo, Marco - CERN
 Cerminara, Gianluca - CERN
@@ -65,8 +65,8 @@ Ferber, Torben - University of British Columbia - Belle II generator and ECL Coo
 Fisk, Ian - Simons Foundation
 Fitzpatrick, Conor - EPFL - LHCb High Level Trigger Project Leader
 Flix, José - PIC & CIEMAT (7)
-Formica Andrea - CEA/Saclay IRFU/Dedip
-Forti Alessandra - The University of Manchester
+Formica, Andrea - CEA/Saclay IRFU/Dedip
+Forti, Alessandra - The University of Manchester
 Gaede, Frank - DESY
 Ganis, Gerardo - CERN
 Gardner, Robert - University of Chicago
@@ -91,13 +91,13 @@ Grandi, Claudio - INFN
 Grasland, Hadrien - CNRS/LAL
 Gray, Heather - LBNL - ATLAS Simulation Coordinator
 Grillo, Lucia - University of Manchester,  LHCb Tracking & Alignment Coordinator
-Guan Wen - University of Wisconsin-Madison
+Guan, Wen - University of Wisconsin-Madison
 Gutsche, Oliver - Fermilab (3)
 Gyurjyan, Vardan - Jefferson Lab
 Hanushevsky, Andrew - SLAC
 Hariri, Farah - CERN
 Harvey, John - CERN 
-Hildreth, Michael, University of Notre Dame (6)
+Hildreth, Michael - University of Notre Dame (6)
 Hegner, Benedikt - CERN
 Heinrich, Lukas - NYU
 Hernández, José M. - CIEMAT (7)
@@ -115,7 +115,7 @@ Kalderon, Charles William - Lund University
 Karavakis, Edward - CERN
 Katz, Daniel S. - University of Illinois Urbana-Champaign
 Kirby, Michael - Fermilab (3)
-Klimentov Alexei - BNL
+Klimentov, Alexei - BNL
 Klute, Markus - MIT
 Komarov, Ilya - INFN Trieste (14)
 Koppenburg, Patrick - Nikhef, Amsterdam
@@ -192,7 +192,7 @@ Schulz, Markus - CERN
 Sciabà, Andrea - CERN
 Seidel, Sally - University of New Mexico
 Sekmen, Sezen - Kyungpook National University
-Serfon Cedric - University of Oslo
+Serfon, Cedric - University of Oslo
 Severini, Horst - University of Oklahoma
 Sexton-Kennedy, Elizabeth - Fermilab (3), CMS Software & Computing Coordinator
 Seymour, Michael - University of Manchester - MCnet

--- a/CWP/papers/roadmap/authors/authors.txt
+++ b/CWP/papers/roadmap/authors/authors.txt
@@ -1,0 +1,229 @@
+﻿Amadio, Guilherme - CERN
+Aphecetche, Laurent - IN2P3/Subatech
+Apostolakis, John - CERN
+Asai, Makoto - SLAC 
+Atzori, Luca - CERN
+Bhimji, Wahid - LBNL 
+Babik, Marian - CERN
+Bagliesi, Giuseppe - INFN
+Bandieramonte, Marilena - CERN
+Barisits, Martin - CERN
+Bauerdick, Lothar A. T. - Fermilab (3)
+Belforte, Stefano - INFN
+Benjamin, Douglas - Duke University
+Bianchi, Riccardo Maria - University of Pittsburgh
+Bird, Ian - CERN - WLCG Project Leader
+Biscarat, Catherine - CNRS/IN2P3, France
+Blomer, Jakob - CERN
+Bloom, Kenneth - University of Nebraska-Lincoln
+Boccali, Tommaso - INFN
+Bockelman, Brian - University of Nebraska - Lincoln
+Bold, Tomasz - UST AGH Krakow
+Bonacorsi, Daniele - University of Bologna, INFN
+Boveia, Antonio - Ohio State University 
+Bozzi, Concezio - INFN
+Britton, David - University of Glasgow
+Buckley, Andy - University of Glasgow
+Buncic, Predrag - CERN - ALICE Computing Coordinator
+Calafiura, Paolo - LBNL
+Campana, Simone - CERN 
+Canali, Luca - CERN
+Carlino Gianpaolo - INFN
+Castro, Nuno - LIP and University of Minho (4)
+Cattaneo, Marco - CERN
+Cerminara, Gianluca - CERN
+Chapman, John - University of Cambridge
+Chang, Philip - UC San Diego
+Childers, Taylor - ANL
+Clarke, Peter - University of Edinburgh
+Cogneras, Eric - CNRS/IN2P3/LPC, Université Clermont Auvergne
+Collier, Ian - STFC
+Corti, Gloria - CERN
+Cosmo, Gabriele - CERN
+Costanzo, Davide - University of Sheffield 
+Couturier, Ben - CERN
+Cranmer, Kyle - New York University
+Crépé-Renaudin, Sabine - CNRS/IN2P3/LPSC
+Cristella, Leonardo - University of Bari, INFN
+Dallmeier-Tiessen, Sünje - CERN
+Di Girolamo, Alessandro - CERN
+De, Kaushik - University of Texas at Arlington
+De Cian, Michel - Heidelberg University
+Doglioni, Caterina - Lund University (8)
+Dotti, Andrea - SLAC
+Duellmann, Dirk - CERN
+Duflot, Laurent - CNRS/LAL
+Dykstra, Dave - Fermilab (3)
+Dziedziniewicz-Wojcik, Katarzyna - CERN
+Dziurda, Agnieszka - CERN - LHCb Tracking & Alignment Coordinator
+Egede, Ulrik - Imperial College London
+Elmer, Peter - Princeton University
+Elmsheuser, Johannes - BNL
+Elvira, V. Daniel - Fermilab (3)
+Eulisse, Giulio - CERN
+Ferber, Torben - University of British Columbia - Belle II generator and ECL Coordinator
+Fisk, Ian - Simons Foundation
+Fitzpatrick, Conor - EPFL - LHCb High Level Trigger Project Leader
+Flix, José - PIC & CIEMAT (7)
+Formica Andrea - CEA/Saclay IRFU/Dedip
+Forti Alessandra - The University of Manchester
+Gaede, Frank - DESY
+Ganis, Gerardo - CERN
+Gardner, Robert - University of Chicago
+Garonne, Vincent - University of Oslo
+Genser, Krzysztof - Fermilab (3)
+George, Simon - Royal Holloway, University of London
+Geurts, Frank - Rice University
+Gheata, Andrei - CERN
+Gheata, Mihaela - CERN
+Giagu, Stefano - Sapienza Università di Roma and INFN
+Gingrich, Douglas - University of Alberta and TRIUMF
+Girone, Maria - CERN
+Gligorov, Vladimir V. - LPNHE, Université Pierre et Marie Curie, Université Paris Diderot, CNRS/IN2P3 (2)
+Ferber, Torben - University of British Columbia
+Glushkov, Ivan - University of Texas at Arlington
+Gohn, Wesley - University of Kentucky
+González Caballero, Isidro - Universidad de Oviedo
+González Fernández, Juan R. - Universidad de Oviedo
+Gonzalez Lopez, Jose Benito - CERN
+Govi, Giacomo - Fermilab
+Grandi, Claudio - INFN
+Grasland, Hadrien - CNRS/LAL
+Gray, Heather - LBNL - ATLAS Simulation Coordinator
+Grillo, Lucia - University of Manchester,  LHCb Tracking & Alignment Coordinator
+Guan Wen - University of Wisconsin-Madison
+Gutsche, Oliver - Fermilab (3)
+Gyurjyan, Vardan - Jefferson Lab
+Hanushevsky, Andrew - SLAC
+Hariri, Farah - CERN
+Harvey, John - CERN 
+Hildreth, Michael, University of Notre Dame (6)
+Hegner, Benedikt - CERN
+Heinrich, Lukas - NYU
+Hernández, José M. - CIEMAT (7)
+Hodgkinson, Mark - University of Sheffield
+Hoeche, Stefan - SLAC National Accelerator Laboratory, MCnet
+Ivanchenko, Vladimir N. - CERN, Tomsk State University Russia
+Ivanov, Todor - University of Sofia, Bulgaria
+Jashal, Brij - TIFR, Mumbai India
+Jayatilaka, Bodhitha - Fermilab (3)
+Jones, Roger - Lancaster University
+Jouvin, Michel - CNRS/LAL, France - Head of Computing Division
+Jun, Soon Yung - Fermilab (3)
+Kagan, Michael - SLAC
+Kalderon, Charles William - Lund University
+Karavakis, Edward - CERN
+Katz, Daniel S. - University of Illinois Urbana-Champaign
+Kirby, Michael - Fermilab (3)
+Klimentov Alexei - BNL
+Klute, Markus - MIT
+Komarov, Ilya - INFN Trieste (14)
+Koppenburg, Patrick - Nikhef, Amsterdam
+Kreczko, Luke - University of Bristol
+Kuhr, Thomas - LMU Munich - Belle II Software Coordinator
+Kuznetsov, Valentin - Cornell University
+Lancon, Eric - BNL
+Lampl, Walter - University of Arizona - ATLAS Software Coordinator
+Lassnig, Mario - CERN
+Laycock, Paul - CERN
+Leggett, Charles - LBNL
+Letts, James - UC San Diego
+Lima, Guilherme - Fermilab
+Linacre, Jacob - Rutherford Appleton Laboratory (13)
+Linden, Tomas - Helsinki Institute of Physics
+Love, Peter - Lancaster University
+Lopienski, Sebastian - CERN
+Lo Presti, Giuseppe - CERN
+Marshall, Zachary L - LBNL
+Martelli, Edoardo - CERN
+Martin-Haugh, Stewart - RAL
+Mato, Pere - CERN
+Mazumdar, Kajari - TIFR, Mumbai India
+Meinhard, Helge - CERN
+Mendez Lorenzo, Patricia - CERN
+McCauley, Thomas - University of Notre Dame
+McKee, Shawn - University of Michigan - ATLAS (12)
+McFayden, Josh - CERN
+McNab, Andrew - University of Manchester - LHCb Computing Deputy Project Leader
+Menasce, Dario - INFN
+Mete, Alaettin Serhan - UC Irvine
+Michelotto, Michele - INFN
+Mitrevski, Jovan - LMU Munich
+Moneta, Lorenzo - CERN
+Morgan, Ben - University of Warwick
+Mount, Richard - SLAC
+Moyse, Edward - University of Massachusetts, Amherst
+Murray, Sean - University of Cape Town/CHPC, Cape Town
+Neubauer, Mark S - University of Illinois Urbana-Champaign (11)
+Novaes, Sérgio - São Paulo State University
+Novak, Mihaly - CERN
+Oyanguren, Arantza - IFIC-Valencia
+Pacheco Pages, Andres - PIC & IFAE (10)
+Paganini, Michela - Yale University
+Pascuzzi, Vincent R. - University of Toronto
+Pearce, Alex - CERN
+Pearson, Ben - MPP Munich
+Pedro, Kevin - Fermilab (3)
+Perdue, Gabriel - Fermilab
+Perez-Calero Yzquierdo, Antonio - PIC & CIEMAT (7)
+Perrozzi, Luca - ETH Zürich
+Petersen, Troels - University of Copenhagen
+Piedra, Jónatan - IFCA (CSIC - Universidad de Cantabria)
+Piilonen, Leo - Virginia Tech (Belle and Belle II) (9)
+Piparo, Danilo - CERN
+Pokorski, Witold - CERN
+Polci, Francesco - LPNHE - LHCb Tracking & Alignment Coordinator
+Potamianos, Karolos - DESY
+Raven, Gerhard - VU Amsterdam/ Nikhef
+Reuter, Jürgen - DESY
+Ribon, Alberto - CERN
+Ritter, Martin - LMU Munich - Belle II, Head of Framework and Infrastructure Group
+Rodrigues, Eduardo - University of Cincinnati (5)
+Roiser, Stefan - CERN - LHCb Computing Project Leader
+Rousseau, David - LAL, Univ. Paris-Sud, CNRS/IN2P3, Université Paris-Saclay, Orsay, France
+Sakuma, Tai - University of Bristol
+Sánchez-Hernández, Alberto - CINVESTAV
+Santana, Renato - Brazilian Centre for Physics Research
+Sartirana, Andrea - CNRS/LLR, France
+Schellman, Heidi - Oregon State University - DUNE computing co-coordinator
+Schovancová, Jaroslava - CERN
+Schramm, Steven - University of Geneva
+Schulz, Markus - CERN
+Sciabà, Andrea - CERN
+Seidel, Sally - University of New Mexico
+Sekmen, Sezen - Kyungpook National University
+Serfon Cedric - University of Oslo
+Severini, Horst - University of Oklahoma
+Sexton-Kennedy, Elizabeth - Fermilab (3), CMS Software & Computing Coordinator
+Seymour, Michael - University of Manchester - MCnet
+Shapoval, Illya - LBNL
+Shiu, Jing-Ge - National Taiwan University
+Shiers, Jamie - CERN
+Short, Hannah - CERN
+Siroli, Gian Piero - University of Bologna & INFN
+Smith, Tim - CERN
+Snyder, Scott - BNL
+Stark, Giordon - University of Chicago
+Stewart, Graeme - CERN - HSF
+Tenaglia, Giacomo - CERN
+Tsulaia, Vakhtang - LBNL
+Tunnell, Christopher - University of Chicago
+Vaandering, Eric - Fermilab (3)
+Valassi, Andrea - CERN
+Valsan, Liviu - CERN
+Vallecorsa, Sofia - Gangneung-Wonju National University, South Korea
+Van Gemmeren, Peter - Argonne National Laboratory
+Vázquez Sierra, Carlos - Nikhef, Amsterdam
+Vernet, Renaud - CC-IN2P3 / CNRS
+Viren, Brett - BNL
+Vuosalo, Carl - University of Wisconsin-Madison
+Wartel, Romain - CERN
+Wenaus, Torre - BNL - ATLAS Computing Coordinator
+Wenzel, Sandro - CERN
+Winklmeier, Frank - University of Oregon
+Wissing, Christoph - DESY
+Wuerthwein, Frank - UCSD
+Wynne, Benjamin - University of Edinburgh
+Yang, Wei - SLAC
+Yazgan, Efe - IHEP, Chinese Academy of Sciences - CMS MC Generators Convener
+Xiaomei, Zhang - IHEP, Chinese Academy of Sciences

--- a/CWP/papers/roadmap/authors/authors.txt
+++ b/CWP/papers/roadmap/authors/authors.txt
@@ -1,4 +1,6 @@
-﻿Amadio, Guilherme - CERN
+Alves Jr, Antonio Augusto - University of Cincinnati
+Amadio, Guilherme - CERN
+Anh-Ky, Nguyen - IOP and GUST, VAST, Hanoi, Viet Nam
 Aphecetche, Laurent - IN2P3/Subatech
 Apostolakis, John - CERN
 Asai, Makoto - SLAC 
@@ -11,9 +13,10 @@ Barisits, Martin - CERN
 Bauerdick, Lothar A. T. - Fermilab (3)
 Belforte, Stefano - INFN
 Benjamin, Douglas - Duke University
+Bernius, Catrin - SLAC
 Bianchi, Riccardo Maria - University of Pittsburgh
 Bird, Ian - CERN - WLCG Project Leader
-Biscarat, Catherine - CNRS/IN2P3, France
+Biscarat, Catherine - CNRS/IN2P3
 Blomer, Jakob - CERN
 Bloom, Kenneth - University of Nebraska-Lincoln
 Boccali, Tommaso - INFN
@@ -22,11 +25,12 @@ Bold, Tomasz - UST AGH Krakow
 Bonacorsi, Daniele - University of Bologna, INFN
 Boveia, Antonio - Ohio State University 
 Bozzi, Concezio - INFN
+Bracko, Marko - University of Maribor and Jozef Stefan Institute, Ljubljana - Belle II Conditions Database Group co-Coordinator
 Britton, David - University of Glasgow
 Buckley, Andy - University of Glasgow
-Buncic, Predrag - CERN - ALICE Computing Coordinator
+Buncic, Predrag - CERN - ALICE Computing Coordinator (1)
 Calafiura, Paolo - LBNL
-Campana, Simone - CERN 
+Campana, Simone - CERN (1)
 Canali, Luca - CERN
 Carlino, Gianpaolo - INFN
 Castro, Nuno - LIP and University of Minho (4)
@@ -36,6 +40,7 @@ Chapman, John - University of Cambridge
 Chang, Philip - UC San Diego
 Childers, Taylor - ANL
 Clarke, Peter - University of Edinburgh
+Clemencic, Marco - CERN
 Cogneras, Eric - CNRS/IN2P3/LPC, Université Clermont Auvergne
 Collier, Ian - STFC
 Corti, Gloria - CERN
@@ -43,8 +48,10 @@ Cosmo, Gabriele - CERN
 Costanzo, Davide - University of Sheffield 
 Couturier, Ben - CERN
 Cranmer, Kyle - New York University
+Cranshaw, Jack - ANL
 Crépé-Renaudin, Sabine - CNRS/IN2P3/LPSC
 Cristella, Leonardo - University of Bari, INFN
+Crooks, David - University of Glasgow
 Dallmeier-Tiessen, Sünje - CERN
 Di Girolamo, Alessandro - CERN
 De, Kaushik - University of Texas at Arlington
@@ -55,13 +62,14 @@ Duellmann, Dirk - CERN
 Duflot, Laurent - CNRS/LAL
 Dykstra, Dave - Fermilab (3)
 Dziedziniewicz-Wojcik, Katarzyna - CERN
-Dziurda, Agnieszka - CERN - LHCb Tracking & Alignment Coordinator
+Dziurda, Agnieszka - CERN - LHCb Tracking and Alignment Coordinator
 Egede, Ulrik - Imperial College London
-Elmer, Peter - Princeton University
+Elmer, Peter - Princeton University (1)
 Elmsheuser, Johannes - BNL
 Elvira, V. Daniel - Fermilab (3)
 Eulisse, Giulio - CERN
 Ferber, Torben - University of British Columbia - Belle II generator and ECL Coordinator
+Filipcic, Andrej - Jozef Stefan Institute
 Fisk, Ian - Simons Foundation
 Fitzpatrick, Conor - EPFL - LHCb High Level Trigger Project Leader
 Flix, José - PIC & CIEMAT (7)
@@ -90,44 +98,51 @@ Govi, Giacomo - Fermilab
 Grandi, Claudio - INFN
 Grasland, Hadrien - CNRS/LAL
 Gray, Heather - LBNL - ATLAS Simulation Coordinator
-Grillo, Lucia - University of Manchester,  LHCb Tracking & Alignment Coordinator
+Grillo, Lucia - University of Manchester,  LHCb Tracking and Alignment Coordinator
 Guan, Wen - University of Wisconsin-Madison
 Gutsche, Oliver - Fermilab (3)
 Gyurjyan, Vardan - Jefferson Lab
 Hanushevsky, Andrew - SLAC
 Hariri, Farah - CERN
-Harvey, John - CERN 
+Harvey, John - CERN (1)
+Hauth, Thomas - KIT
 Hildreth, Michael - University of Notre Dame (6)
-Hegner, Benedikt - CERN
+Hegner, Benedikt - CERN (1)
 Heinrich, Lukas - NYU
 Hernández, José M. - CIEMAT (7)
 Hodgkinson, Mark - University of Sheffield
 Hoeche, Stefan - SLAC National Accelerator Laboratory, MCnet
-Ivanchenko, Vladimir N. - CERN, Tomsk State University Russia
+Hristov, Peter - CERN
+Huang, Xingtao - Shandong University
+Ivanchenko, Vladimir N. - CERN & Tomsk State University Russia
 Ivanov, Todor - University of Sofia, Bulgaria
 Jashal, Brij - TIFR, Mumbai India
 Jayatilaka, Bodhitha - Fermilab (3)
-Jones, Roger - Lancaster University
-Jouvin, Michel - CNRS/LAL, France - Head of Computing Division
+Jones, Roger - Lancaster University (1)
+Jouvin, Michel - CNRS/LAL, France - Head of Computing Division (1)
 Jun, Soon Yung - Fermilab (3)
 Kagan, Michael - SLAC
 Kalderon, Charles William - Lund University
 Karavakis, Edward - CERN
 Katz, Daniel S. - University of Illinois Urbana-Champaign
+Kersevan, Borut Paul - University of Ljubljana
 Kirby, Michael - Fermilab (3)
 Klimentov, Alexei - BNL
 Klute, Markus - MIT
 Komarov, Ilya - INFN Trieste (14)
 Koppenburg, Patrick - Nikhef, Amsterdam
 Kreczko, Luke - University of Bristol
-Kuhr, Thomas - LMU Munich - Belle II Software Coordinator
+Kuhr, Thomas - LMU Munich - Belle II Software Coordinator (1)
+Kutschke, Robert - Fermilab - Mu2e Head of Software and Simulations (1,3)
 Kuznetsov, Valentin - Cornell University
 Lancon, Eric - BNL
 Lampl, Walter - University of Arizona - ATLAS Software Coordinator
+Lange, David - Princeton University
 Lassnig, Mario - CERN
 Laycock, Paul - CERN
 Leggett, Charles - LBNL
 Letts, James - UC San Diego
+Li, Teng - University of Edinburgh
 Lima, Guilherme - Fermilab
 Linacre, Jacob - Rutherford Appleton Laboratory (13)
 Linden, Tomas - Helsinki Institute of Physics
@@ -136,7 +151,7 @@ Lopienski, Sebastian - CERN
 Lo Presti, Giuseppe - CERN
 Marshall, Zachary L - LBNL
 Martelli, Edoardo - CERN
-Martin-Haugh, Stewart - RAL
+Martin-Haugh, Stewart - STFC RAL
 Mato, Pere - CERN
 Mazumdar, Kajari - TIFR, Mumbai India
 Meinhard, Helge - CERN
@@ -145,7 +160,7 @@ McCauley, Thomas - University of Notre Dame
 McKee, Shawn - University of Michigan - ATLAS (12)
 McFayden, Josh - CERN
 McNab, Andrew - University of Manchester - LHCb Computing Deputy Project Leader
-Menasce, Dario - INFN
+Menasce, Dario - INFN (1)
 Mete, Alaettin Serhan - UC Irvine
 Michelotto, Michele - INFN
 Mitrevski, Jovan - LMU Munich
@@ -154,12 +169,13 @@ Morgan, Ben - University of Warwick
 Mount, Richard - SLAC
 Moyse, Edward - University of Massachusetts, Amherst
 Murray, Sean - University of Cape Town/CHPC, Cape Town
-Neubauer, Mark S - University of Illinois Urbana-Champaign (11)
+Neubauer, Mark S - University of Illinois Urbana-Champaign (1,11)
 Novaes, Sérgio - São Paulo State University
 Novak, Mihaly - CERN
 Oyanguren, Arantza - IFIC-Valencia
 Pacheco Pages, Andres - PIC & IFAE (10)
 Paganini, Michela - Yale University
+Pansanel, Jerome - IPHC, Université de Strasbourg, CNRS
 Pascuzzi, Vincent R. - University of Toronto
 Pearce, Alex - CERN
 Pearson, Ben - MPP Munich
@@ -169,18 +185,21 @@ Perez-Calero Yzquierdo, Antonio - PIC & CIEMAT (7)
 Perrozzi, Luca - ETH Zürich
 Petersen, Troels - University of Copenhagen
 Piedra, Jónatan - IFCA (CSIC - Universidad de Cantabria)
-Piilonen, Leo - Virginia Tech (Belle and Belle II) (9)
+Piilonen, Leo - Virginia Tech - Belle and Belle II (9)
 Piparo, Danilo - CERN
 Pokorski, Witold - CERN
-Polci, Francesco - LPNHE - LHCb Tracking & Alignment Coordinator
+Polci, Francesco - LPNHE - LHCb Tracking and Alignment Coordinator
 Potamianos, Karolos - DESY
+Psihas, Fernanda - Indiana University
 Raven, Gerhard - VU Amsterdam/ Nikhef
 Reuter, Jürgen - DESY
 Ribon, Alberto - CERN
 Ritter, Martin - LMU Munich - Belle II, Head of Framework and Infrastructure Group
-Rodrigues, Eduardo - University of Cincinnati (5)
-Roiser, Stefan - CERN - LHCb Computing Project Leader
+Robinson, James - DESY
+Rodrigues, Eduardo - University of Cincinnati (1,5)
+Roiser, Stefan - CERN - LHCb Computing Project Leader (1)
 Rousseau, David - LAL, Univ. Paris-Sud, CNRS/IN2P3, Université Paris-Saclay, Orsay, France
+Roy, Gareth - University of Glasgow
 Sakuma, Tai - University of Bristol
 Sánchez-Hernández, Alberto - CINVESTAV
 Santana, Renato - Brazilian Centre for Physics Research
@@ -194,17 +213,22 @@ Seidel, Sally - University of New Mexico
 Sekmen, Sezen - Kyungpook National University
 Serfon, Cedric - University of Oslo
 Severini, Horst - University of Oklahoma
-Sexton-Kennedy, Elizabeth - Fermilab (3), CMS Software & Computing Coordinator
+Sexton-Kennedy, Elizabeth - Fermilab - CMS Software and Computing Coordinator (1,3)
 Seymour, Michael - University of Manchester - MCnet
 Shapoval, Illya - LBNL
 Shiu, Jing-Ge - National Taiwan University
 Shiers, Jamie - CERN
 Short, Hannah - CERN
 Siroli, Gian Piero - University of Bologna & INFN
+Skipsey, Sam - University of Glasgow
 Smith, Tim - CERN
 Snyder, Scott - BNL
+Sokoloff, Michael D - University of Cincinnati 
+Stadie, Hartmut - Universität Hamburg
 Stark, Giordon - University of Chicago
-Stewart, Graeme - CERN - HSF
+Stewart, Graeme - CERN - HSF (1)
+Stewart, Gordon - University of Glasgow
+Templon, Jeff - Nikhef, Amsterdam, NL
 Tenaglia, Giacomo - CERN
 Tsulaia, Vakhtang - LBNL
 Tunnell, Christopher - University of Chicago
@@ -212,10 +236,11 @@ Vaandering, Eric - Fermilab (3)
 Valassi, Andrea - CERN
 Valsan, Liviu - CERN
 Vallecorsa, Sofia - Gangneung-Wonju National University, South Korea
-Van Gemmeren, Peter - Argonne National Laboratory
+Van Gemmeren, Peter - ANL
 Vázquez Sierra, Carlos - Nikhef, Amsterdam
 Vernet, Renaud - CC-IN2P3 / CNRS
 Viren, Brett - BNL
+Vlimant, Jean-Roch - California Institute of Technology - (1)
 Vuosalo, Carl - University of Wisconsin-Madison
 Wartel, Romain - CERN
 Wenaus, Torre - BNL - ATLAS Computing Coordinator

--- a/CWP/papers/roadmap/authors/authors.txt
+++ b/CWP/papers/roadmap/authors/authors.txt
@@ -1,254 +1,267 @@
-Alves Jr, Antonio Augusto - University of Cincinnati
+Alves Jr, Antonio Augusto - UCincinnati
 Amadio, Guilherme - CERN
-Anh-Ky, Nguyen - IOP and GUST, VAST, Hanoi, Viet Nam
-Aphecetche, Laurent - IN2P3/Subatech
+Anh-Ky, Nguyen - VAST
+Aphecetche, Laurent - Subatech
 Apostolakis, John - CERN
-Asai, Makoto - SLAC 
+Asai, Makoto - SLAC (16)
 Atzori, Luca - CERN
-Bhimji, Wahid - LBNL 
 Babik, Marian - CERN
-Bagliesi, Giuseppe - INFN
+Bagliesi, Giuseppe - INFNPISA
 Bandieramonte, Marilena - CERN
 Barisits, Martin - CERN
 Bauerdick, Lothar A. T. - Fermilab (3)
-Belforte, Stefano - INFN
-Benjamin, Douglas - Duke University
+Belforte, Stefano - INFNTRIESTE
+Benjamin, Douglas - UDuke
 Bernius, Catrin - SLAC
-Bianchi, Riccardo Maria - University of Pittsburgh
+Bhimji, Wahid - LBNL
+Bianchi, Riccardo Maria - UPittsburgh
 Bird, Ian - CERN - WLCG Project Leader
-Biscarat, Catherine - CNRS/IN2P3
+Biscarat, Catherine - LPSC
 Blomer, Jakob - CERN
-Bloom, Kenneth - University of Nebraska-Lincoln
-Boccali, Tommaso - INFN
-Bockelman, Brian - University of Nebraska - Lincoln
-Bold, Tomasz - UST AGH Krakow
-Bonacorsi, Daniele - University of Bologna, INFN
-Boveia, Antonio - Ohio State University 
-Bozzi, Concezio - INFN
-Bracko, Marko - University of Maribor and Jozef Stefan Institute, Ljubljana - Belle II Conditions Database Group co-Coordinator
-Britton, David - University of Glasgow
-Buckley, Andy - University of Glasgow
+Bloom, Kenneth - UNebraska
+Boccali, Tommaso - INFNPISA
+Bockelman, Brian - UNebraska
+Bold, Tomasz - KRAKOWUST
+Bonacorsi, Daniele - INFNBOLOGNA
+Boveia, Antonio - UOhio
+Bozzi, Concezio - INFNFerrara
+Bracko, Marko - UMaribor & JSI - Belle II Conditions Database Group co-Coordinator
+Britton, David - UGlasgow
+Buckley, Andy - UGlasgow
 Buncic, Predrag - CERN - ALICE Computing Coordinator (1)
 Calafiura, Paolo - LBNL
 Campana, Simone - CERN (1)
+Canal, Philippe - Fermilab (3)
 Canali, Luca - CERN
-Carlino, Gianpaolo - INFN
-Castro, Nuno - LIP and University of Minho (4)
+Carlino, Gianpaolo - INFNNapoli
+Castro, Nuno - LIP & UMinho (4)
 Cattaneo, Marco - CERN
 Cerminara, Gianluca - CERN
-Chapman, John - University of Cambridge
-Chang, Philip - UC San Diego
+Chang, Philip - UCSD
+Chapman, John - UCambridge
 Childers, Taylor - ANL
-Clarke, Peter - University of Edinburgh
+Clarke, Peter - UEDINBURGH
 Clemencic, Marco - CERN
-Cogneras, Eric - CNRS/IN2P3/LPC, Université Clermont Auvergne
-Collier, Ian - STFC
+Cogneras, Eric - LPCClermont
+Collier, Ian - RAL
 Corti, Gloria - CERN
 Cosmo, Gabriele - CERN
-Costanzo, Davide - University of Sheffield 
+Costanzo, Davide - USheffield
 Couturier, Ben - CERN
-Cranmer, Kyle - New York University
+Cranmer, Kyle - NYU
 Cranshaw, Jack - ANL
-Crépé-Renaudin, Sabine - CNRS/IN2P3/LPSC
-Cristella, Leonardo - University of Bari, INFN
-Crooks, David - University of Glasgow
+Crépé-Renaudin, Sabine - LPSC
+Cristella, Leonardo - INFNBari
+Crooks, David - UGlasgow
 Dallmeier-Tiessen, Sünje - CERN
+De Cian, Michel - UHeidelberg
+De, Kaushik - UTexas
 Di Girolamo, Alessandro - CERN
-De, Kaushik - University of Texas at Arlington
-De Cian, Michel - Heidelberg University
-Doglioni, Caterina - Lund University (8)
-Dotti, Andrea - SLAC
+Dimitrov, Gancho - CERN
+Doglioni, Caterina - ULund (8)
+Dotti, Andrea - SLAC (16)
 Duellmann, Dirk - CERN
-Duflot, Laurent - CNRS/LAL
+Duflot, Laurent - LAL
 Dykstra, Dave - Fermilab (3)
 Dziedziniewicz-Wojcik, Katarzyna - CERN
 Dziurda, Agnieszka - CERN - LHCb Tracking and Alignment Coordinator
-Egede, Ulrik - Imperial College London
-Elmer, Peter - Princeton University (1)
+Egede, Ulrik - Imperial
+Elmer, Peter - UPrinceton (1)
 Elmsheuser, Johannes - BNL
 Elvira, V. Daniel - Fermilab (3)
 Eulisse, Giulio - CERN
-Ferber, Torben - University of British Columbia - Belle II generator and ECL Coordinator
-Filipcic, Andrej - Jozef Stefan Institute
-Fisk, Ian - Simons Foundation
+Ferber, Torben - UBritishColumbia - Belle II generator and ECL Coordinator
+Filipcic, Andrej - JSI
+Fisk, Ian - SimonsFoundation
 Fitzpatrick, Conor - EPFL - LHCb High Level Trigger Project Leader
 Flix, José - PIC & CIEMAT (7)
-Formica, Andrea - CEA/Saclay IRFU/Dedip
-Forti, Alessandra - The University of Manchester
+Formica, Andrea - Irfu
+Forti, Alessandra - UManchester
 Gaede, Frank - DESY
 Ganis, Gerardo - CERN
-Gardner, Robert - University of Chicago
-Garonne, Vincent - University of Oslo
+Gardner, Robert - UChicago
+Garonne, Vincent - UOslo
+Gellrich, Andreas - DESY
 Genser, Krzysztof - Fermilab (3)
-George, Simon - Royal Holloway, University of London
-Geurts, Frank - Rice University
+George, Simon - RHU
+Geurts, Frank - URice
 Gheata, Andrei - CERN
 Gheata, Mihaela - CERN
-Giagu, Stefano - Sapienza Università di Roma and INFN
-Gingrich, Douglas - University of Alberta and TRIUMF
+Giacomini, Francesco - CNAF
+Giagu, Stefano - USapienza & INFNRoma
+Giffels, Manuel - KIT
+Gingrich, Douglas - UAlberta
 Girone, Maria - CERN
-Gligorov, Vladimir V. - LPNHE, Université Pierre et Marie Curie, Université Paris Diderot, CNRS/IN2P3 (2)
-Ferber, Torben - University of British Columbia
-Glushkov, Ivan - University of Texas at Arlington
-Gohn, Wesley - University of Kentucky
-González Caballero, Isidro - Universidad de Oviedo
-González Fernández, Juan R. - Universidad de Oviedo
+Gligorov, Vladimir V. - LPNHE
+Glushkov, Ivan - UTexas
+Gohn, Wesley - UKentucky
+González Caballero, Isidro - UOviedo
+González Fernández, Juan R. - UOviedo
 Gonzalez Lopez, Jose Benito - CERN
 Govi, Giacomo - Fermilab
-Grandi, Claudio - INFN
-Grasland, Hadrien - CNRS/LAL
+Grandi, Claudio - INFNBOLOGNA
+Grasland, Hadrien - LAL
 Gray, Heather - LBNL - ATLAS Simulation Coordinator
-Grillo, Lucia - University of Manchester,  LHCb Tracking and Alignment Coordinator
-Guan, Wen - University of Wisconsin-Madison
+Grillo, Lucia - UManchester -  LHCb Tracking and Alignment Coordinator
+Guan, Wen - UWisconsin
 Gutsche, Oliver - Fermilab (3)
-Gyurjyan, Vardan - Jefferson Lab
-Hanushevsky, Andrew - SLAC
+Gyurjyan, Vardan - JLab
+Hanushevsky, Andrew - SLAC (16)
 Hariri, Farah - CERN
+Hartmann, Thomas - DESY
 Harvey, John - CERN (1)
 Hauth, Thomas - KIT
-Hildreth, Michael - University of Notre Dame (6)
 Hegner, Benedikt - CERN (1)
+Heinemann, Beate - DESY
 Heinrich, Lukas - NYU
 Hernández, José M. - CIEMAT (7)
-Hodgkinson, Mark - University of Sheffield
-Hoeche, Stefan - SLAC National Accelerator Laboratory, MCnet
+Hildreth, Michael - UNotreDame (6)
+Hodgkinson, Mark - USheffield
+Hoeche, Stefan - SLAC - MCnet (16)
 Hristov, Peter - CERN
-Huang, Xingtao - Shandong University
-Ivanchenko, Vladimir N. - CERN & Tomsk State University Russia
-Ivanov, Todor - University of Sofia, Bulgaria
-Jashal, Brij - TIFR, Mumbai India
+Huang, Xingtao - UShandong
+Ivanchenko, Vladimir N. - CERN & UTomsk
+Ivanov, Todor - USofia
+Jashal, Brij - TIFR
 Jayatilaka, Bodhitha - Fermilab (3)
-Jones, Roger - Lancaster University (1)
-Jouvin, Michel - CNRS/LAL, France - Head of Computing Division (1)
+Jones, Roger - ULancaster (1)
+Jouvin, Michel - LAL (1)
 Jun, Soon Yung - Fermilab (3)
-Kagan, Michael - SLAC
-Kalderon, Charles William - Lund University
+Kagan, Michael - SLAC (16)
+Kalderon, Charles William - ULund
 Karavakis, Edward - CERN
-Katz, Daniel S. - University of Illinois Urbana-Champaign
-Kersevan, Borut Paul - University of Ljubljana
+Katz, Daniel S. - UChampaign
+Kcira, Dorian - Caltech
+Kersevan, Borut Paul - ULjubljana
 Kirby, Michael - Fermilab (3)
 Klimentov, Alexei - BNL
 Klute, Markus - MIT
-Komarov, Ilya - INFN Trieste (14)
-Koppenburg, Patrick - Nikhef, Amsterdam
-Kreczko, Luke - University of Bristol
-Kuhr, Thomas - LMU Munich - Belle II Software Coordinator (1)
+Komarov, Ilya - INFNTRIESTE (14)
+Koppenburg, Patrick - NIKHEF
+Kowalkowski, Jim - Fermilab (3)
+Kreczko, Luke - UBristol
+Kuhr, Thomas - LMU - Belle II Software Coordinator (1)
 Kutschke, Robert - Fermilab - Mu2e Head of Software and Simulations (1,3)
-Kuznetsov, Valentin - Cornell University
+Kuznetsov, Valentin - Cornell
+Lampl, Walter - UArizona - ATLAS Software Coordinator
 Lancon, Eric - BNL
-Lampl, Walter - University of Arizona - ATLAS Software Coordinator
-Lange, David - Princeton University
+Lange, David - UPrinceton
 Lassnig, Mario - CERN
 Laycock, Paul - CERN
 Leggett, Charles - LBNL
-Letts, James - UC San Diego
-Li, Teng - University of Edinburgh
+Letts, James - UCSD
+Lewendel, Birgit - DESY
+Li, Teng - UEDINBURGH
 Lima, Guilherme - Fermilab
-Linacre, Jacob - Rutherford Appleton Laboratory (13)
-Linden, Tomas - Helsinki Institute of Physics
-Love, Peter - Lancaster University
-Lopienski, Sebastian - CERN
+Linacre, Jacob - RAL (13)
+Linden, Tomas - HIP
 Lo Presti, Giuseppe - CERN
+Lopienski, Sebastian - CERN
+Love, Peter - ULancaster
 Marshall, Zachary L - LBNL
 Martelli, Edoardo - CERN
-Martin-Haugh, Stewart - STFC RAL
+Martin-Haugh, Stewart - RAL
 Mato, Pere - CERN
-Mazumdar, Kajari - TIFR, Mumbai India
-Meinhard, Helge - CERN
-Mendez Lorenzo, Patricia - CERN
-McCauley, Thomas - University of Notre Dame
-McKee, Shawn - University of Michigan - ATLAS (12)
+Mazumdar, Kajari - TIFR
+McCauley, Thomas - UNotreDame
 McFayden, Josh - CERN
-McNab, Andrew - University of Manchester - LHCb Computing Deputy Project Leader
-Menasce, Dario - INFN (1)
-Mete, Alaettin Serhan - UC Irvine
-Michelotto, Michele - INFN
-Mitrevski, Jovan - LMU Munich
+McKee, Shawn - UMich - ATLAS (12)
+McNab, Andrew - UManchester - LHCb Computing Deputy Project Leader
+Meinhard, Helge - CERN
+Menasce, Dario - INFNMilano (1)
+Mendez Lorenzo, Patricia - CERN
+Mete, Alaettin Serhan - UCIrvine
+Michelotto, Michele - INFNPadova
+Mitrevski, Jovan - LMU
 Moneta, Lorenzo - CERN
-Morgan, Ben - University of Warwick
-Mount, Richard - SLAC
-Moyse, Edward - University of Massachusetts, Amherst
-Murray, Sean - University of Cape Town/CHPC, Cape Town
-Neubauer, Mark S - University of Illinois Urbana-Champaign (1,11)
-Novaes, Sérgio - São Paulo State University
+Morgan, Ben - UWarwick
+Mount, Richard - SLAC (16)
+Moyse, Edward - UAmherst
+Murray, Sean - UCape & CPHC
+Neubauer, Mark S - UChampaign (1,11)
+Novaes, Sérgio - USaoPaolo
 Novak, Mihaly - CERN
-Oyanguren, Arantza - IFIC-Valencia
+Oyanguren, Arantza - IFICValencia
+Ozturk, Nurcan - UTexas
 Pacheco Pages, Andres - PIC & IFAE (10)
-Paganini, Michela - Yale University
-Pansanel, Jerome - IPHC, Université de Strasbourg, CNRS
-Pascuzzi, Vincent R. - University of Toronto
+Paganini, Michela - UYale
+Pansanel, Jerome - IPHC
+Pascuzzi, Vincent R. - UTorronto
 Pearce, Alex - CERN
-Pearson, Ben - MPP Munich
+Pearson, Ben - MPP
 Pedro, Kevin - Fermilab (3)
 Perdue, Gabriel - Fermilab
 Perez-Calero Yzquierdo, Antonio - PIC & CIEMAT (7)
-Perrozzi, Luca - ETH Zürich
-Petersen, Troels - University of Copenhagen
-Piedra, Jónatan - IFCA (CSIC - Universidad de Cantabria)
-Piilonen, Leo - Virginia Tech - Belle and Belle II (9)
+Perrozzi, Luca - ETHZurich
+Petersen, Troels - NBI
+Petric, Marko - CERN
+Piedra, Jónatan - IFCA
+Piilonen, Leo - VIRTECH - Belle & Belle II (9)
 Piparo, Danilo - CERN
 Pokorski, Witold - CERN
 Polci, Francesco - LPNHE - LHCb Tracking and Alignment Coordinator
 Potamianos, Karolos - DESY
-Psihas, Fernanda - Indiana University
-Raven, Gerhard - VU Amsterdam/ Nikhef
+Psihas, Fernanda - INDIANA
+Raven, Gerhard - NIKHEF
 Reuter, Jürgen - DESY
 Ribon, Alberto - CERN
-Ritter, Martin - LMU Munich - Belle II, Head of Framework and Infrastructure Group
+Ritter, Martin - LMU - Belle II, Head of Framework and Infrastructure Group
 Robinson, James - DESY
-Rodrigues, Eduardo - University of Cincinnati (1,5)
+Rodrigues, Eduardo - UCincinnati (1,5)
 Roiser, Stefan - CERN - LHCb Computing Project Leader (1)
-Rousseau, David - LAL, Univ. Paris-Sud, CNRS/IN2P3, Université Paris-Saclay, Orsay, France
-Roy, Gareth - University of Glasgow
-Sakuma, Tai - University of Bristol
-Sánchez-Hernández, Alberto - CINVESTAV
-Santana, Renato - Brazilian Centre for Physics Research
-Sartirana, Andrea - CNRS/LLR, France
-Schellman, Heidi - Oregon State University - DUNE computing co-coordinator
+Rousseau, David - LAL
+Roy, Gareth - UGlasgow
+Sailer, Andre - CERN
+Sakuma, Tai - UBristol
+Sánchez-Hernández, Alberto - CINVESTAV (15)
+Santana, Renato - CBPF
+Sartirana, Andrea - LLR
+Schellman, Heidi - OREGON - DUNE computing co-coordinator
 Schovancová, Jaroslava - CERN
-Schramm, Steven - University of Geneva
+Schramm, Steven - UGeneva
 Schulz, Markus - CERN
 Sciabà, Andrea - CERN
-Seidel, Sally - University of New Mexico
-Sekmen, Sezen - Kyungpook National University
-Serfon, Cedric - University of Oslo
-Severini, Horst - University of Oklahoma
+Seidel, Sally - UNewMexico
+Sekmen, Sezen - KYUNGPOOK
+Serfon, Cedric - UOSLO
+Severini, Horst - UOKLAHOMA
 Sexton-Kennedy, Elizabeth - Fermilab - CMS Software and Computing Coordinator (1,3)
-Seymour, Michael - University of Manchester - MCnet
+Seymour, Michael - UManchester - MCnet
 Shapoval, Illya - LBNL
-Shiu, Jing-Ge - National Taiwan University
 Shiers, Jamie - CERN
+Shiu, Jing-Ge - TAIWAN
 Short, Hannah - CERN
-Siroli, Gian Piero - University of Bologna & INFN
-Skipsey, Sam - University of Glasgow
+Siroli, Gian Piero - INFNBOLOGNA
+Skipsey, Sam - UGlasgow
 Smith, Tim - CERN
 Snyder, Scott - BNL
-Sokoloff, Michael D - University of Cincinnati 
-Stadie, Hartmut - Universität Hamburg
-Stark, Giordon - University of Chicago
+Sokoloff, Michael D - UCincinnati (1)
+Stadie, Hartmut - HAMBURG
+Stark, Giordon - CHICAGO
+Stewart, Gordon - UGlasgow
 Stewart, Graeme - CERN - HSF (1)
-Stewart, Gordon - University of Glasgow
-Templon, Jeff - Nikhef, Amsterdam, NL
+Templon, Jeff - NIKHEF
 Tenaglia, Giacomo - CERN
 Tsulaia, Vakhtang - LBNL
-Tunnell, Christopher - University of Chicago
+Tunnell, Christopher - CHICAGO
 Vaandering, Eric - Fermilab (3)
 Valassi, Andrea - CERN
+Vallecorsa, Sofia - UGangneung
 Valsan, Liviu - CERN
-Vallecorsa, Sofia - Gangneung-Wonju National University, South Korea
 Van Gemmeren, Peter - ANL
-Vázquez Sierra, Carlos - Nikhef, Amsterdam
-Vernet, Renaud - CC-IN2P3 / CNRS
+Vázquez Sierra, Carlos - NIKHEF
+Vernet, Renaud - CCIN2P3
 Viren, Brett - BNL
-Vlimant, Jean-Roch - California Institute of Technology - (1)
-Vuosalo, Carl - University of Wisconsin-Madison
+Vlimant, Jean-Roch - Caltech (1)
+Voss, Christian - DESY
+Vuosalo, Carl - WISCONSIN
 Wartel, Romain - CERN
 Wenaus, Torre - BNL - ATLAS Computing Coordinator
 Wenzel, Sandro - CERN
-Winklmeier, Frank - University of Oregon
+Winklmeier, Frank - OREGON
 Wissing, Christoph - DESY
 Wuerthwein, Frank - UCSD
-Wynne, Benjamin - University of Edinburgh
-Yang, Wei - SLAC
-Yazgan, Efe - IHEP, Chinese Academy of Sciences - CMS MC Generators Convener
-Xiaomei, Zhang - IHEP, Chinese Academy of Sciences
+Wynne, Benjamin - UEDINBURGH
+Xiaomei, Zhang - IHEPCHINA
+Yang, Wei - SLAC (16)
+Yazgan, Efe - IHEPCHINA - CMS MC Generators Convener

--- a/CWP/papers/roadmap/authors/authors.txt
+++ b/CWP/papers/roadmap/authors/authors.txt
@@ -39,6 +39,7 @@ Cattaneo, Marco - CERN
 Cerminara, Gianluca - CERN
 Chapman, John - UCambridge
 Chang, Philip - UCSD
+Chen, Gang - IHEP
 Childers, Taylor - ANL
 Clarke, Peter - UEDINBURGH
 Clemencic, Marco - CERN
@@ -262,6 +263,6 @@ Winklmeier, Frank - OREGON
 Wissing, Christoph - DESY
 Wuerthwein, Frank - UCSD
 Wynne, Benjamin - UEDINBURGH
-Xiaomei, Zhang - IHEPCHINA
+Xiaomei, Zhang - IHEP
 Yang, Wei - SLAC (16)
-Yazgan, Efe - IHEPCHINA - CMS MC Generators Convener
+Yazgan, Efe - IHEP - CMS MC Generators Convener

--- a/CWP/papers/roadmap/authors/authors.txt
+++ b/CWP/papers/roadmap/authors/authors.txt
@@ -5,6 +5,7 @@ Aphecetche, Laurent - Subatech
 Apostolakis, John - CERN
 Asai, Makoto - SLAC (16)
 Atzori, Luca - CERN
+Bhimji, Wahid - LBNL
 Babik, Marian - CERN
 Bagliesi, Giuseppe - INFNPISA
 Bandieramonte, Marilena - CERN
@@ -13,7 +14,6 @@ Bauerdick, Lothar A. T. - Fermilab (3)
 Belforte, Stefano - INFNTRIESTE
 Benjamin, Douglas - UDuke
 Bernius, Catrin - SLAC
-Bhimji, Wahid - LBNL
 Bianchi, Riccardo Maria - UPittsburgh
 Bird, Ian - CERN - WLCG Project Leader
 Biscarat, Catherine - LPSC
@@ -37,8 +37,8 @@ Carlino, Gianpaolo - INFNNapoli
 Castro, Nuno - LIP & UMinho (4)
 Cattaneo, Marco - CERN
 Cerminara, Gianluca - CERN
-Chang, Philip - UCSD
 Chapman, John - UCambridge
+Chang, Philip - UCSD
 Childers, Taylor - ANL
 Clarke, Peter - UEDINBURGH
 Clemencic, Marco - CERN
@@ -54,10 +54,10 @@ Crépé-Renaudin, Sabine - LPSC
 Cristella, Leonardo - INFNBari
 Crooks, David - UGlasgow
 Dallmeier-Tiessen, Sünje - CERN
-De Cian, Michel - UHeidelberg
-De, Kaushik - UTexas
 Di Girolamo, Alessandro - CERN
 Dimitrov, Gancho - CERN
+De, Kaushik - UTexas
+De Cian, Michel - UHeidelberg
 Doglioni, Caterina - ULund (8)
 Dotti, Andrea - SLAC (16)
 Duellmann, Dirk - CERN
@@ -87,12 +87,12 @@ George, Simon - RHU
 Geurts, Frank - URice
 Gheata, Andrei - CERN
 Gheata, Mihaela - CERN
-Giacomini, Francesco - CNAF
 Giagu, Stefano - USapienza & INFNRoma
 Giffels, Manuel - KIT
 Gingrich, Douglas - UAlberta
 Girone, Maria - CERN
 Gligorov, Vladimir V. - LPNHE
+Giacomini, Francesco - CNAF
 Glushkov, Ivan - UTexas
 Gohn, Wesley - UKentucky
 González Caballero, Isidro - UOviedo
@@ -108,8 +108,8 @@ Gutsche, Oliver - Fermilab (3)
 Gyurjyan, Vardan - JLab
 Hanushevsky, Andrew - SLAC (16)
 Hariri, Farah - CERN
-Hartmann, Thomas - DESY
 Harvey, John - CERN (1)
+Hartmann, Thomas - DESY
 Hauth, Thomas - KIT
 Hegner, Benedikt - CERN (1)
 Heinemann, Beate - DESY
@@ -143,8 +143,8 @@ Kreczko, Luke - UBristol
 Kuhr, Thomas - LMU - Belle II Software Coordinator (1)
 Kutschke, Robert - Fermilab - Mu2e Head of Software and Simulations (1,3)
 Kuznetsov, Valentin - Cornell
-Lampl, Walter - UArizona - ATLAS Software Coordinator
 Lancon, Eric - BNL
+Lampl, Walter - UArizona - ATLAS Software Coordinator
 Lange, David - UPrinceton
 Lassnig, Mario - CERN
 Laycock, Paul - CERN
@@ -254,7 +254,7 @@ Vernet, Renaud - CCIN2P3
 Viren, Brett - BNL
 Vlimant, Jean-Roch - Caltech (1)
 Voss, Christian - DESY
-Vuosalo, Carl - WISCONSIN
+Vuosalo, Carl - UWisconsin
 Wartel, Romain - CERN
 Wenaus, Torre - BNL - ATLAS Computing Coordinator
 Wenzel, Sandro - CERN

--- a/CWP/papers/roadmap/authors/footnotes.txt
+++ b/CWP/papers/roadmap/authors/footnotes.txt
@@ -1,0 +1,13 @@
+﻿1. Vladimir V. Gligorov acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 724777 “RECEPT'”.
+2. Supported by the US-DOE, DE-AC02-07CH11359
+3. Supported by FCT-Portugal, IF/00050/2013/CP1172/CT0002
+4. Supported by the US-NSF, ACI-1450319
+5. Supported by the US-NSF, PHY-1607578
+6. Supported by ES-MINECO, FPA2016-80994-c2-1-R & MDM-2015-0509        
+7. Caterina Doglioni acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 679305 “DARKJETS”.
+8. Supported by the US-DOE, DE-SC0009973
+9. Supported by the ES-MINECO FPA2016-80994-C2-2-R
+10. Supported by the US-DOE, DE-SC0018098 and US-NSF ACI-1558233
+11. Supported by the US-DOE, DE-SC0007859 and US-NSF, 76749/1136652/2
+12. Supported by funding from the European Union’s Horizon 2020 research and innovation programme under the Marie Skłodowska-Curie grant agreement No. 752730
+13. Supported by Swiss National Science Foundation, Early Postdoc Mobility Fellowship, project number P2ELP2_168556

--- a/CWP/papers/roadmap/authors/footnotes.txt
+++ b/CWP/papers/roadmap/authors/footnotes.txt
@@ -1,13 +1,14 @@
-﻿1. Vladimir V. Gligorov acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 724777 “RECEPT'”.
-2. Supported by the US-DOE, DE-AC02-07CH11359
-3. Supported by FCT-Portugal, IF/00050/2013/CP1172/CT0002
-4. Supported by the US-NSF, ACI-1450319
-5. Supported by the US-NSF, PHY-1607578
-6. Supported by ES-MINECO, FPA2016-80994-c2-1-R & MDM-2015-0509        
-7. Caterina Doglioni acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 679305 “DARKJETS”.
-8. Supported by the US-DOE, DE-SC0009973
-9. Supported by the ES-MINECO FPA2016-80994-C2-2-R
-10. Supported by the US-DOE, DE-SC0018098 and US-NSF ACI-1558233
-11. Supported by the US-DOE, DE-SC0007859 and US-NSF, 76749/1136652/2
-12. Supported by funding from the European Union’s Horizon 2020 research and innovation programme under the Marie Skłodowska-Curie grant agreement No. 752730
-13. Supported by Swiss National Science Foundation, Early Postdoc Mobility Fellowship, project number P2ELP2_168556
+1. Community White Paper Editorial Board Member 
+2. Vladimir V. Gligorov acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 724777 “RECEPT'”.
+3. Supported by the US-DOE, DE-AC02-07CH11359
+4. Supported by FCT-Portugal, IF/00050/2013/CP1172/CT0002
+5. Supported by the US-NSF, ACI-1450319
+6. Supported by the US-NSF, PHY-1607578
+7. Supported by ES-MINECO, FPA2016-80994-c2-1-R & MDM-2015-0509        
+8. Caterina Doglioni acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 679305 “DARKJETS”.
+9. Supported by the US-DOE, DE-SC0009973
+10. Supported by the ES-MINECO FPA2016-80994-C2-2-R
+11. Supported by the US-DOE, DE-SC0018098 and US-NSF ACI-1558233
+12. Supported by the US-DOE, DE-SC0007859 and US-NSF, 76749/1136652/2
+13. Supported by funding from the European Union’s Horizon 2020 research and innovation programme under the Marie Skłodowska-Curie grant agreement No. 752730
+14. Supported by Swiss National Science Foundation, Early Postdoc Mobility Fellowship, project number P2ELP2_168556

--- a/CWP/papers/roadmap/authors/footnotes.txt
+++ b/CWP/papers/roadmap/authors/footnotes.txt
@@ -1,14 +1,16 @@
 1. Community White Paper Editorial Board Member 
-2. Vladimir V. Gligorov acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 724777 “RECEPT'”.
+2. Vladimir V. Gligorov acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 724777 “RECEPT”.
 3. Supported by the US-DOE, DE-AC02-07CH11359
 4. Supported by FCT-Portugal, IF/00050/2013/CP1172/CT0002
 5. Supported by the US-NSF, ACI-1450319
 6. Supported by the US-NSF, PHY-1607578
-7. Supported by ES-MINECO, FPA2016-80994-c2-1-R & MDM-2015-0509        
+7. Supported by ES-MINECO, FPA2016-80994-c2-1-R \& MDM-2015-0509
 8. Caterina Doglioni acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 679305 “DARKJETS”.
 9. Supported by the US-DOE, DE-SC0009973
 10. Supported by the ES-MINECO FPA2016-80994-C2-2-R
 11. Supported by the US-DOE, DE-SC0018098 and US-NSF ACI-1558233
 12. Supported by the US-DOE, DE-SC0007859 and US-NSF, 76749/1136652/2
 13. Supported by funding from the European Union’s Horizon 2020 research and innovation programme under the Marie Skłodowska-Curie grant agreement No. 752730
-14. Supported by Swiss National Science Foundation, Early Postdoc Mobility Fellowship, project number P2ELP2_168556
+14. Supported by Swiss National Science Foundation, Early Postdoc Mobility Fellowship, project number P2ELP2\_168556
+15. Supported by CONACYT (Mexico)
+16. Supported by the US-DOE, DE-AC02-76SF0051

--- a/CWP/papers/roadmap/authors/footnotes.txt
+++ b/CWP/papers/roadmap/authors/footnotes.txt
@@ -4,13 +4,13 @@
 4. Supported by FCT-Portugal, IF/00050/2013/CP1172/CT0002
 5. Supported by the US-NSF, ACI-1450319
 6. Supported by the US-NSF, PHY-1607578
-7. Supported by ES-MINECO, FPA2016-80994-c2-1-R \& MDM-2015-0509
+7. Supported by ES-MINECO, FPA2016-80994-c2-1-R & MDM-2015-0509
 8. Caterina Doglioni acknowledges funding from the European Research Council (ERC) under the European Union's Horizon 2020 research and innovation programme under grant agreement No 679305 “DARKJETS”.
 9. Supported by the US-DOE, DE-SC0009973
 10. Supported by the ES-MINECO FPA2016-80994-C2-2-R
 11. Supported by the US-DOE, DE-SC0018098 and US-NSF ACI-1558233
 12. Supported by the US-DOE, DE-SC0007859 and US-NSF, 76749/1136652/2
 13. Supported by funding from the European Union’s Horizon 2020 research and innovation programme under the Marie Skłodowska-Curie grant agreement No. 752730
-14. Supported by Swiss National Science Foundation, Early Postdoc Mobility Fellowship, project number P2ELP2\_168556
+14. Supported by Swiss National Science Foundation, Early Postdoc Mobility Fellowship, project number P2ELP2_168556
 15. Supported by CONACYT (Mexico)
 16. Supported by the US-DOE, DE-AC02-76SF0051


### PR DESCRIPTION
This is an improved version of the script used for the final version v1. New features are:
-  Authors are printed in alphabetical order, independently of the source file order
- LaTeX special characters in affiliations and footnotes are properly escaped (except `\` unlikely to be present as a content character)
- An exception is raised if an author affiliation key has no associated definition
- A parser allows to define input and output files.

This version required Python v3..

This PR contains the source files that were used to generate the v1  (with some special characters manually escaped) and an updated version of the source file, without the manual escape of special characters and with affiliation fixed for one author.