### PR TITLE
fix bug in relative path to bib

### DIFF
--- a/CWP/papers/HSF-CWP-2017-05_analysis/latex/cwp-wg-analysis-interpretation.tex
+++ b/CWP/papers/HSF-CWP-2017-05_analysis/latex/cwp-wg-analysis-interpretation.tex
@@ -33,47 +33,56 @@
 \title{HEP Software Foundation Community White Paper Working Group -- Data Analysis and Interpretation}
 
 \author{HEP Software Foundation:}
-\author[1]{Riccardo Maria Bianchi}
-\author[2]{Brian Bockelman}
-\author[3]{Nuno Castro}
-\author[4]{Peter Elmer}
-\author[16]{Robert Gardner}
-\author[14]{Maria Girone}
-\author[5]{Oliver Gutsche}
-\author[14]{Benedikt Hegner}
-\author[6]{Jos\'{e} M. Hern\'{a}ndez}
-\author[5]{Bodhitha Jayatilaka}
-\author[4]{David Lange}
-\author[7]{Mark Neubauer}
-\author[7]{Daniel S. Katz}
-\author[8]{Lukasz Kreczko}
-\author[9]{James Letts}
-\author[10]{Shawn McKee}
-\author[11]{Christoph Paus}
-\author[5]{Kevin Pedro}
-\author[12]{Eduardo Rodrigues}
-\author[8]{Tai Sakuma}
-\author[5]{Elizabeth Sexton-Kennedy}
-\author[13]{Michael D. Sokoloff}
-\author[9]{Frank W\"{u}rthwein}
-\author[15]{Carl Vuosalo}
+\author[a]{Riccardo Maria Bianchi}
+\author[b]{Brian Bockelman}
+\author[c,d]{Nuno Castro}
+\author[e]{Peter Elmer}
+\author[f]{Robert Gardner}
+\author[g]{Maria Girone}
+\author[h,1]{Oliver Gutsche}
+\author[g]{Benedikt Hegner}
+\author[i]{Jos\'{e} M. Hern\'{a}ndez}
+\author[h]{Bodhitha Jayatilaka}
+\author[e]{David Lange}
+\author[j,1]{Mark Neubauer}
+\author[j]{Daniel S. Katz}
+\author[k]{Lukasz Kreczko}
+\author[l]{James Letts}
+\author[m]{Shawn McKee}
+\author[n]{Christoph Paus}
+\author[h]{Kevin Pedro}
+\author[o]{Eduardo Rodrigues}
+\author[k]{Tai Sakuma}
+\author[h]{Elizabeth Sexton-Kennedy}
+\author[o]{Michael D. Sokoloff}
+\author[l]{Frank W\"{u}rthwein}
+\author[p]{Carl Vuosalo}
 
-\affiliation[1]{University of Pittsburgh}
-\affiliation[2]{University of Nebraska-Lincoln}
-\affiliation[3]{LIP and University of Minho, Supported by FCT-Portugal, IF/00050/2013/CP1172/CT0002}
-\affiliation[4]{Princeton University}
-\affiliation[5]{Fermi National Accelerator Laboratory, Supported by the US-DOE, DE-AC02-07CH11359}
-\affiliation[6]{CIEMAT, Supported by ES-MINECO, FPA2016-80994-c2-1-R and MDM-2015-0509}
-\affiliation[7]{University of Illinois Urbana-Champaign}
-\affiliation[8]{University of Bristol}
-\affiliation[9]{UC San Diego}
-\affiliation[10]{University of Michigan, Supported by the US-DOE, DE-SC0007859 and US-NSF, 76749/1136652/2}
-\affiliation[11]{Massachusetts Institute of Technology}
-\affiliation[12]{University of Cincinnati, Supported by the US-NSF, ACI-1450319}
-\affiliation[13]{University of Cincinnati, Supported by the US-NSF, ACI-1558219}
-\affiliation[14]{CERN}
-\affiliation[15]{University of Wisconsin-Madison}
-\affiliation[16]{University of Chicago}
+\affiliation[a]{University of Pittsburgh, Pittsburgh, Pennsylvania, USA}
+\affiliation[b]{University of Nebraska-Lincoln, Lincoln, Nebraska, USA}
+\affiliation[c]{Laboratório de Instrumentação e Física Experimental de Partículas, Lisbon, Portugal}
+\affiliation[d]{University of Minho, Braga, Portugal}
+\affiliation[e]{Princeton University, Princeton, New Jersey, USA}
+\affiliation[f]{University of Chicago, Chicago, Illinois, USA}
+\affiliation[g]{CERN, Geneva, Switzerland}
+\affiliation[h]{Fermi National Accelerator Laboratory, Batavia, Illinois USA}
+\affiliation[i]{Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas, Madrid, Spain}
+\affiliation[j]{University of Illinois at Urbana-Champaign, Urbana, Illinois USA}
+\affiliation[k]{University of Bristol, Bristol, UK}
+\affiliation[l]{University of California at San Diego, La Jolla, California, USA}
+\affiliation[m]{University of Michigan, Ann Arbor, Michigan, USA}
+\affiliation[n]{Massachusetts Institute of Technology, Cambridge, Massachusetts, USA}
+\affiliation[o]{University of Cincinnati, Cincinnati, Ohio, USA}
+\affiliation[p]{University of Wisconsin-Madison, Madison, Wisconsin, USA}
+\affiliation[1]{Paper Editor}
+
+%\affiliation[c]{Laboratório de Instrumentação e Física Experimental de Partículas, Lisbon, Portugal and University of Minho, Braga, Portugal, Supported by FCT-Portugal, IF/00050/2013/CP1172/CT0002}
+%\affiliation[g]{Fermi National Accelerator Laboratory, Batavia, Illinois USA, Supported by the US-DOE, DE-AC02-07CH11359}
+%\affiliation[h]{Centro de Investigaciones Energéticas, Medioambientales y Tecnológicas (CIEMAT), Madrid, Spain, Supported by ES-MINECO, FPA2016-80994-c2-1-R and MDM-2015-0509}
+%\affiliation[i]{University of Illinois at Urbana-Champaign, Urbana, Illinois USA, Supported by the US-DOE, DE-SC0018098 and US-NSF ACI-1558233}
+%\affiliation[m]{University of Michigan, Supported by the US-DOE, DE-SC0007859 and US-NSF, 76749/1136652/2}
+%\affiliation[o]{University of Cincinnati, Supported by the US-NSF, ACI-1450319}
+%\affiliation[p]{University of Cincinnati, Supported by the US-NSF, ACI-1558219}
 
 \maketitle
 

--- a/CWP/papers/HSF-CWP-2017-13_soft-dev/latex/cwp-wg-software-development.tex
+++ b/CWP/papers/HSF-CWP-2017-13_soft-dev/latex/cwp-wg-software-development.tex
@@ -11,8 +11,8 @@
 \usepackage[utf8]{inputenc}
 
 \usepackage[style=numeric-comp,sorting=none]{biblatex}
-\addbibresource{../../roadmap/latex/cwp.bib}
-\addbibresource{../../roadmap/latex/cwp-chapters.bib}
+\addbibresource{../../HSF-CWP-2017-01_roadmap/latex/cwp.bib}
+\addbibresource{../../HSF-CWP-2017-01_roadmap/latex/cwp-chapters.bib}
 
 %% Comment out before final submission
 %\usepackage{lineno}  % for line numbering during review


### PR DESCRIPTION
Updating analysis CWP paper for arXiv. In that process, noticed that the software-development paper need an update to relative path to bib from CWP roadmap document. 