### PR TITLE
Two subsections for training needs.

### DIFF
--- a/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
+++ b/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
@@ -290,12 +290,15 @@ The HEP user community consists of a set of users with diverse software
 experience, interests, and time availablity to learn new techniques.  Any
 training program must take into account the variation in target audiences. For
 example, an undergraduate doing a summer research project has different needs
-and skills than their mentoring professor.
-For purposes of training, it is useful to think of all our user community as
-\emph{students}. More specifically, we can broadly identify four different sets
-of students, classified by experience level, recognizing that even within these
-groups there will be people who will learn at different speeds and with
-differing depths of understanding:
+and skills than their mentoring professor. For purposes of training, we will
+name all our user community as \emph{students}.
+
+%____________________________________________________________________
+\subsection{Classification of trainees}
+
+We can broadly identify four different sets of students, classified by experience level,
+recognizing that even within these groups there will be people who will learn at different
+speeds and with differing depths of understanding:
 
 \begin{itemize}
    \item \emph{Beginners}: New collaborators with no knowledge of the 


### PR DESCRIPTION
Silghtly reorganize "Training needs" so to get two subsections instead of one.